### PR TITLE
Fix for http://drupal.org/node/2271419

### DIFF
--- a/src/Entity/FileEntity.php
+++ b/src/Entity/FileEntity.php
@@ -127,7 +127,7 @@ class FileEntity extends File {
       ))
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayOptions('form', array(
-        'type' => 'string',
+        'type' => 'string_textfield',
         'weight' => -5,
       ))
       ->setDisplayConfigurable('form', TRUE);


### PR DESCRIPTION
After http://drupal.org/node/2271419 using type 'string' no longer works - needs to be 'string_textfield'
