### PR TITLE
Replaced deprecated language_load function

### DIFF
--- a/file_entity.tokens.inc
+++ b/file_entity.tokens.inc
@@ -65,8 +65,8 @@ function file_entity_tokens($type, $tokens, array $data = array(), array $option
 
   $url_options = array('absolute' => TRUE);
   if (isset($options['langcode'])) {
-    $url_options['language'] = language_load($options['langcode']);
     $langcode = $options['langcode'];
+    $url_options['language'] = \Drupal::languageManager()->getLanguage($langcode);
   }
   else {
     $langcode = NULL;


### PR DESCRIPTION
Replaced language_load() function with \Drupal::languageManager()->getLanguage() in file_entity.tokens.inc
