### PR TITLE
Modified updateBundle() method to create fields which might not have exi...

### DIFF
--- a/src/Entity/FileEntity.php
+++ b/src/Entity/FileEntity.php
@@ -83,6 +83,16 @@ class FileEntity extends File {
     if ($this->bundle() === FILE_TYPE_NONE) {
       $this->updateBundle();
     }
+    // If the original file entity is empty.
+    // And the updated bundle is different than the original bundle.
+    if (!empty($this->original) && $this->bundle() != $this->original->bundle()) {
+      // We set the original type field.
+      $this->original->get('type')->target_id = $this->bundle();
+      $this->original->fieldDefinitions = NULL;
+      $this->original->typedData = NULL;
+      // And set the original entity keys cache.
+      $this->original->entityKeys['bundle'] = $this->bundle();
+    }
 
     // Fetch image dimensions.
     module_load_include('inc', 'file_entity', 'file_entity.file');
@@ -108,16 +118,6 @@ class FileEntity extends File {
     $this->typedData = NULL;
     // Update the entity keys cache.
     $this->entityKeys['bundle'] = $type;
-    // Later on the original will be compared to the new entity, which fails if some fields do not exist.
-    if(!empty($this->original)) {
-      // Set the original type field.
-      $this->original->get('type')->target_id = $type;
-      // Set the field definitions, so that they will be fetched for the new bundle.
-      $this->original->fieldDefinitions = NULL;
-      $this->original->typedData = NULL;
-      // Set the original entity keys cache.
-      $this->original->entityKeys['bundle'] = $type;
-    }
   }
 
   /**

--- a/src/Entity/FileEntity.php
+++ b/src/Entity/FileEntity.php
@@ -83,14 +83,13 @@ class FileEntity extends File {
     if ($this->bundle() === FILE_TYPE_NONE) {
       $this->updateBundle();
     }
-    // If the original file entity is empty.
-    // And the updated bundle is different than the original bundle.
+    // \Drupal\Core\Entity\ContentEntityStorageBase::hasFieldChanged() expects
+    // that the original entity has the same fields. Update the bundle if it was
+    // changed.
     if (!empty($this->original) && $this->bundle() != $this->original->bundle()) {
-      // We set the original type field.
       $this->original->get('type')->target_id = $this->bundle();
       $this->original->fieldDefinitions = NULL;
       $this->original->typedData = NULL;
-      // And set the original entity keys cache.
       $this->original->entityKeys['bundle'] = $this->bundle();
     }
 

--- a/src/Entity/FileEntity.php
+++ b/src/Entity/FileEntity.php
@@ -108,6 +108,16 @@ class FileEntity extends File {
     $this->typedData = NULL;
     // Update the entity keys cache.
     $this->entityKeys['bundle'] = $type;
+    // Later on the original will be compared to the new entity, which fails if some fields do not exist.
+    if(!empty($this->original)) {
+      // Set the original type field.
+      $this->original->get('type')->target_id = $type;
+      // Set the field definitions, so that they will be fetched for the new bundle.
+      $this->original->fieldDefinitions = NULL;
+      $this->original->typedData = NULL;
+      // Set the original entity keys cache.
+      $this->original->entityKeys['bundle'] = $type;
+    }
   }
 
   /**

--- a/src/Tests/FileEntityAdminTest.php
+++ b/src/Tests/FileEntityAdminTest.php
@@ -282,6 +282,7 @@ class FileEntityAdminTest extends FileEntityTestBase {
   public function testUsageView() {
     $this->container->get('module_installer')->install(array('node'));
     $file = $this->createFileEntity(array('uid' => $this->userAdmin));
+    // Next line causes an exception, core issue.
     $this->drupalLogin($this->userAdmin);
 
     // Check the usage links on the file overview.

--- a/src/Tests/FileEntityCacheTagsTest.php
+++ b/src/Tests/FileEntityCacheTagsTest.php
@@ -88,7 +88,7 @@ class FileEntityCacheTagsTest extends FileEntityTestBase {
           'target_id' => $file2->id(),
           'display' => 1,
           'description' => '',
-        )
+        ),
       ),
     ));
     $node2->save();
@@ -106,7 +106,7 @@ class FileEntityCacheTagsTest extends FileEntityTestBase {
     $node3->save();
 
     // Check cache tags.
-    $contexts = ['languages:language_interface', 'user.permissions', 'theme', 'timezone', 'user.roles'];
+    $contexts = ['languages:language_interface', 'user.permissions', 'theme', 'timezone'];
     $this->assertPageCacheContextsAndTags($node1->urlInfo(), $contexts, [
       'node:' . $node1->id(),
       'node_view',

--- a/src/Tests/FileEntityTypeTest.php
+++ b/src/Tests/FileEntityTypeTest.php
@@ -109,7 +109,6 @@ class FileEntityTypeTest extends FileEntityTestBase {
     $edit = array();
     $edit["{$field_name}[0][value]"] = $this->randomMachineName();
     $edit['filename[0][value]'] = $this->randomMachineName();
-    debug($edit, "Edit array");
     $this->drupalPostForm(NULL, $edit, t('Save'));
     $this->assertRaw(t('!type %name was uploaded.', array('!type' => 'Image 2', '%name' => $edit['filename[0][value]'])));
 

--- a/src/Tests/FileEntityTypeTest.php
+++ b/src/Tests/FileEntityTypeTest.php
@@ -109,6 +109,7 @@ class FileEntityTypeTest extends FileEntityTestBase {
     $edit = array();
     $edit["{$field_name}[0][value]"] = $this->randomMachineName();
     $edit['filename[0][value]'] = $this->randomMachineName();
+    debug($edit, "Edit array");
     $this->drupalPostForm(NULL, $edit, t('Save'));
     $this->assertRaw(t('!type %name was uploaded.', array('!type' => 'Image 2', '%name' => $edit['filename[0][value]'])));
 


### PR DESCRIPTION
...sted in the original file bundle

removed user.roles from cache contexts in CacheTagsTest because they aren't set by core anymore and file_entity doesn't use them.
