### PR TITLE
Fix test

### DIFF
--- a/src/Tests/FileEntityNormalizerTest.php
+++ b/src/Tests/FileEntityNormalizerTest.php
@@ -27,7 +27,7 @@ class FileEntityNormalizerTest extends KernelTestBase {
    * {@inheritdoc}
    */
   public static $modules = array(
-    'entity',
+    'simpletest',
     'field',
     'file',
     'file_entity',


### PR DESCRIPTION
Entity had to be removed from the modules list, afterwards it was complaining about simpletest not being in the file system, so I added it. Tests are now passing (still the one exception about content.page_1 from views).
