### PR TITLE
Added cleaning of "\r" to the mimeType getter

### DIFF
--- a/src/Entity/FileType.php
+++ b/src/Entity/FileType.php
@@ -92,7 +92,16 @@ class FileType extends ConfigEntityBundleBase implements FileTypeInterface {
    * {@inheritdoc}
    */
   public function getMimeTypes() {
-    return $this->mimetypes ?: array();
+    if($this->mimetypes){
+      $cleanedMimeTypes = [];
+      foreach ($this->mimetypes as $mimeType){
+        $cleanedMimeTypes[] = str_replace("\r", '',$mimeType);
+      }
+
+      return $cleanedMimeTypes;
+    }else{
+      return [];
+    }
   }
 
   /**


### PR DESCRIPTION
If you edit for example the document file type and add a new mimetype the mimetypes are saved as this:

"application/pdf\r" because of the text area.

This results in a empty "file Type" screen on the "add file screen" and forbids to add a new file.

This solution is not perfect but the setter is never called ( perhaps only on install? )
Just wanted to clearify the problem, perhaps you have a better solution for this problem, for example not saving them with "\r" ?

Greetings,

Rainer
