### PR TITLE
Fix test fails related to missing tasks/actions links.

### DIFF
--- a/src/Tests/FileEntityAdminTest.php
+++ b/src/Tests/FileEntityAdminTest.php
@@ -37,10 +37,20 @@ class FileEntityAdminTest extends FileEntityTestBase {
   protected $userEditDelete;
 
   /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = ['block'];
+
+  /**
    * {@inheritdoc}
    */
   public function setUp() {
     parent::setUp();
+    // Add the tasks and actions blocks.
+    $this->drupalPlaceBlock('local_actions_block');
+    $this->drupalPlaceBlock('local_tasks_block');
 
     // Remove the "view files" permission which is set
     // by default for all users so we can test this permission

--- a/src/Tests/FileEntityEditTest.php
+++ b/src/Tests/FileEntityEditTest.php
@@ -18,8 +18,13 @@ class FileEntityEditTest extends FileEntityTestBase {
   protected $web_user;
   protected $admin_user;
 
+  public static $modules = ['block'];
+
   function setUp() {
     parent::setUp();
+    // Add the tasks and actions blocks.
+    $this->drupalPlaceBlock('local_actions_block');
+    $this->drupalPlaceBlock('local_tasks_block');
 
     $this->web_user = $this->drupalCreateUser(array('edit own document files', 'create files'));
     $this->admin_user = $this->drupalCreateUser(array('bypass file access', 'administer files'));


### PR DESCRIPTION
With a recent core change, tasks and actions are now blocks so they can be easily themed. Tests that require/use those links have to enable the block module and place the relevant blocks ('local_tasks/actions_block'). This PR does that for file_entity.
