### PR TITLE
Set file entity type as viewable

### DIFF
--- a/file_entity.module
+++ b/file_entity.module
@@ -639,6 +639,7 @@ function file_entity_entity_type_alter(&$entity_types) {
     ->set('entity_keys', $keys)
     ->set('bundle_entity_type', 'file_type')
     ->set('admin_permission', 'administer files')
+    ->set('viewable', TRUE)
     ->setClass('Drupal\file_entity\Entity\FileEntity')
     ->setHandlerClass('storage_schema', 'Drupal\file_entity\FileEntityStorageSchema')
     ->setFormClass('default', 'Drupal\file_entity\Form\FileEditForm')


### PR DESCRIPTION
If the core patch in https://www.drupal.org/node/2567919#comment-10326241 is accepted, we will need to mark the File entity type as viewable manually, since core will have marked it as not viewable with the change.
