### PR TITLE
Add getType() method to FileType.php to fix module installation.

### DIFF
--- a/src/Entity/FileType.php
+++ b/src/Entity/FileType.php
@@ -91,6 +91,13 @@ class FileType extends ConfigEntityBundleBase implements FileTypeInterface {
   /**
    * {@inheritdoc}
    */
+  public function getType() {
+    return $this->type;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getMimeTypes() {
     return $this->mimetypes ?: array();
   }


### PR DESCRIPTION
Hey there, 

this attempts to fix module installation/activation (?). Otherwise, we get a 

Uncaught PHP Exception Drupal\Core\Entity\Exception\NoCorrespondingEntityClassException: "The Drupal\file_entity\Entity\FileType class does not correspond to an entity type." at ...\core\lib\Drupal\Core\Entity\EntityTypeRepository.php line 103"

Error.
