### PR TITLE
Add hal.module as dependency.

### DIFF
--- a/file_entity.info.yml
+++ b/file_entity.info.yml
@@ -8,4 +8,5 @@ dependencies:
   - text
   - views
   - image
+  - hal
 configure: file_entity.settings


### PR DESCRIPTION
This gets rid of another error on module installation/activation - 

"Fatal error: Class 'Drupal\hal\Normalizer\ContentEntityNormalizer' not found in ...\modules\contrib\file_entity\src\Normalizer\FileEntityNormalizer.php on line 15"

by adding hal.module as a dependency.
