### PR TITLE
Add check for HAL module, which in turn requires REST module

### DIFF
--- a/src/FileEntityServiceProvider.php
+++ b/src/FileEntityServiceProvider.php
@@ -21,7 +21,8 @@ class FileEntityServiceProvider extends ServiceProviderBase {
    */
   public function alter(ContainerBuilder $container) {
     $modules = $container->getParameter('container.modules');
-    if (isset($modules['rest'])) {
+    // Check for installed REST & HAL modules, as HAL requires REST.
+    if (isset($modules['hal']) ) {
       // Add a normalizer service for file entities.
       $service_definition = new Definition('Drupal\file_entity\Normalizer\FileEntityNormalizer', array(
         new Reference('rest.link_manager'),


### PR DESCRIPTION
This gets rid of a possibly occuring error on module installation/activation if REST, but no HAL is installed -

"Fatal error: Class 'Drupal\hal\Normalizer\ContentEntityNormalizer' not found in ...\modules\contrib\file_entity\src\Normalizer\FileEntityNormalizer.php on line 15"

by checking for HAL instead of REST (which is sufficient b/c HAL requires REST).
